### PR TITLE
Add EAM Light

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # awesome-cern
 An opinionated curated list of awesome open source frameworks, libraries and software developed by CERN for the world.
 
+## Engineering
+- [EAM Light](https://eam-opensource.web.cern.ch/content/eam-light): light-weight web application for HxGN EAM.
+
 ## Open Science
 
 ### Digital repositories


### PR DESCRIPTION
There are in fact [two components](https://eam-opensource.web.cern.ch/), but EAM Light is really the end product. Can be re-categorized later, as further projects get added.